### PR TITLE
Set logging level to debug when users log in through ckan session

### DIFF
--- a/ckanext/oauth2/plugin.py
+++ b/ckanext/oauth2/plugin.py
@@ -152,7 +152,7 @@ class OAuth2Plugin(plugins.SingletonPlugin):
         # If the authentication via API fails, we can still log in the user using session.
         if user_name is None and 'repoze.who.identity' in environ:
             user_name = environ['repoze.who.identity']['repoze.who.userid']
-            log.info('User %s logged using session' % user_name)
+            log.debug('User %s logged using session' % user_name)
 
         # If we have been able to log in the user (via API or Session)
         if user_name:


### PR DESCRIPTION
Set logging level to debug when users log in through normal session to avoid verbose logs to avoid verbose logs.

This is PR is a fix for https://gitlab.com/keitaro/unhcr-project-support/-/issues/29